### PR TITLE
Allow VideoPost to return the actual video_url

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/Blog.java
+++ b/src/main/java/com/tumblr/jumblr/types/Blog.java
@@ -12,7 +12,7 @@ public class Blog extends Resource {
     private String name;
     private String title;
     private String description;
-    private int posts, likes, followers, drafts, queue;
+    private int posts, likes, followers;
     private Long updated;
     private boolean ask, ask_anon;
 
@@ -54,22 +54,6 @@ public class Blog extends Resource {
      */
     public Integer getLikeCount() {
         return this.likes;
-    }
-
-    /**
-     * Get the number of drafts for this blog
-     * @return int the number of drafts
-     */
-    public Integer getDraftCount() {
-        return this.drafts;
-    }
-
-    /**
-     * Get the number of Queued Posts for this blog
-     * @return int the number of Queued Posts
-     */
-    public Integer getQueuedCount() {
-        return this.queue;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/Blog.java
+++ b/src/main/java/com/tumblr/jumblr/types/Blog.java
@@ -12,7 +12,7 @@ public class Blog extends Resource {
     private String name;
     private String title;
     private String description;
-    private int posts, likes, followers;
+    private int posts, likes, followers, drafts, queue;
     private Long updated;
     private boolean ask, ask_anon;
 
@@ -54,6 +54,22 @@ public class Blog extends Resource {
      */
     public Integer getLikeCount() {
         return this.likes;
+    }
+
+    /**
+     * Get the number of drafts for this blog
+     * @return int the number of drafts
+     */
+    public Integer getDraftCount() {
+        return this.drafts;
+    }
+
+    /**
+     * Get the number of Queued Posts for this blog
+     * @return int the number of Queued Posts
+     */
+    public Integer getQueuedCount() {
+        return this.queue;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -12,7 +12,7 @@ public class VideoPost extends Post {
 
     private List<Video> player;
     private String caption;
-    private String embed, permalink_url;
+    private String embed, permalink_url, video_url;
     private File data;
     private String thumbnail_url;
     private int thumbnail_width;
@@ -23,6 +23,13 @@ public class VideoPost extends Post {
      */
     public String getPermalinkUrl() {
         return permalink_url;
+    }
+
+    /**
+     * Get the direct URL for this video
+     */
+    public String getVideoUrl() {
+        return video_url;
     }
 
     /**


### PR DESCRIPTION
The VideoPost class is missing the definition and return of the field video_url. This adds this field as a valid return for this class.
